### PR TITLE
minor refactor: use file and file_line instead of exec w/ unless grep

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -35,8 +35,8 @@ define pyenv::install(
 
   file { $shrc:
     ensure => present,
-    owner   => $user,
-    group   => $group,
+    owner  => $user,
+    group  => $group,
   }
 
   file_line { "pyenv::shrc ${user}":

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,12 +33,18 @@ define pyenv::install(
     require => Exec["pyenv::checkout ${user}"],
   }
 
-  exec { "pyenv::shrc ${user}":
-    command => "echo 'source ${pyenvrc}' >> ${shrc}",
-    user    => $user,
+  file { $shrc:
+    ensure => present,
+    owner   => $user,
     group   => $group,
-    unless  => "grep -q pyenvrc ${shrc}",
-    path    => ['/bin', '/usr/bin', '/usr/sbin'],
-    require => File["pyenv::pyenvrc ${user}"],
+  }
+
+  file_line { "pyenv::shrc ${user}":
+    path    => $shrc,
+    line    => "source ${pyenvrc}",
+    require => [
+      File["pyenv::pyenvrc ${user}"],
+      File[$shrc],
+    ],
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,11 +33,13 @@ define pyenv::install(
     require => Exec["pyenv::checkout ${user}"],
   }
 
-  file { $shrc:
+  @file { $shrc:
     ensure => present,
     owner  => $user,
     group  => $group,
   }
+
+  realize File[$shrc]
 
   file_line { "pyenv::shrc ${user}":
     path    => $shrc,

--- a/spec/defines/install_spec.rb
+++ b/spec/defines/install_spec.rb
@@ -11,10 +11,10 @@ describe 'pyenv::install', :type => :define do
         with_command("git clone https://github.com/yyuu/pyenv.git /home/#{user}/.pyenv")
     end
 
-    it "appends in a rc file, a command to include .pyenv/bin folder in PATH env variable" do
-      should contain_exec("pyenv::shrc #{user}").
-        with_command("echo 'source /home/#{user}/.pyenvrc' >> /home/#{user}/.profile").
-        with_path(['/bin','/usr/bin','/usr/sbin'])
+    it "adds a line to the rc file, a command to include .pyenv/bin folder in PATH env variable" do
+      should contain_file_line("pyenv::shrc #{user}").
+        with_line("source /home/#{user}/.pyenvrc").
+        with_path("/home/#{user}/.profile")
     end
   end
 end


### PR DESCRIPTION
`file` creates `.profile` if needed, `file_line` ensures it has the `source` line in it.

cf. https://forge.puppet.com/puppetlabs/stdlib#file_line