### PR TITLE
List all packages + some fixes

### DIFF
--- a/lib/puppet/provider/pip/default.rb
+++ b/lib/puppet/provider/pip/default.rb
@@ -8,10 +8,11 @@ Puppet::Type.type(:pip).provide :default do
   def install
     command = ['install']
 
-    return if query
     if @resource[:package].kind_of?(Array)
       if @resource[:package_version] and @resource[:package_version].kind_of?(Array)
         @resource[:package].zip(@resource[:package_version]) { |p, v| command << p.to_s + v.to_s }
+      elsif query
+        return
       else
         command << @resource[:package]
       end

--- a/lib/puppet/provider/pip/default.rb
+++ b/lib/puppet/provider/pip/default.rb
@@ -8,14 +8,16 @@ Puppet::Type.type(:pip).provide :default do
   def install
     command = ['install']
 
-    if @resource[:package].kind_of?(Array)
-      if @resource[:package_version] and @resource[:package_version].kind_of?(Array)
-        @resource[:package].zip(@resource[:package_version]) { |p, v| command << p.to_s + v.to_s }
+    unless query
+      if @resource[:package].kind_of?(Array)
+        if @resource[:package_version] and @resource[:package_version].kind_of?(Array)
+          @resource[:package].zip(@resource[:package_version]) { |p, v| command << p.to_s + v.to_s }
+        else
+          command << @resource[:package]
+        end
       else
-        command << @resource[:package]
+        command << @resource[:package] + @resource[:package_version].to_s
       end
-    else
-      command << @resource[:package] + @resource[:package_version].to_s
     end
 
     execute(command)

--- a/lib/puppet/provider/pip/default.rb
+++ b/lib/puppet/provider/pip/default.rb
@@ -59,7 +59,7 @@ Puppet::Type.type(:pip).provide :default do
   end
 
   def list(options = {})
-    command = ['freeze']
+    command = ['freeze --all']
     packages = execute(command)
     Array.new.tap do |item|
       packages.split("\n").each do |package|

--- a/lib/puppet/provider/pip/default.rb
+++ b/lib/puppet/provider/pip/default.rb
@@ -8,16 +8,15 @@ Puppet::Type.type(:pip).provide :default do
   def install
     command = ['install']
 
-    unless query
-      if @resource[:package].kind_of?(Array)
-        if @resource[:package_version] and @resource[:package_version].kind_of?(Array)
-          @resource[:package].zip(@resource[:package_version]) { |p, v| command << p.to_s + v.to_s }
-        else
-          command << @resource[:package]
-        end
+    return if query
+    if @resource[:package].kind_of?(Array)
+      if @resource[:package_version] and @resource[:package_version].kind_of?(Array)
+        @resource[:package].zip(@resource[:package_version]) { |p, v| command << p.to_s + v.to_s }
       else
-        command << @resource[:package] + @resource[:package_version].to_s
+        command << @resource[:package]
       end
+    else
+      command << @resource[:package] + @resource[:package_version].to_s
     end
 
     execute(command)

--- a/lib/puppet/provider/pip/default.rb
+++ b/lib/puppet/provider/pip/default.rb
@@ -69,11 +69,11 @@ Puppet::Type.type(:pip).provide :default do
   end
 
   def list(options = {})
-    command = ['freeze --all']
+    command = ['list']
     packages = execute(command)
     Array.new.tap do |item|
       packages.split("\n").each do |package|
-        match = /^(.*)==(.*)$/.match(package)
+        match = /^(.*) \((.*)\)$/.match(package)
         item << {
           :package => match[1],
           :ensure  => match[2],


### PR DESCRIPTION
*Main purpose*: enable Puppet to list all installed python packages.

`pip` can do it with `pip freeze --all`, but `--all` option is absent in old versions of `pip`. Hense, I've changed query command from `freeze` to `list`, which show all installed packages and updated regex match.

*Other changes*:
* fix of array propagation: `+=` instead of `<<`
* suppress Puppet error if package is already installed and desired state is "present"